### PR TITLE
Fix python3 error about comparing instances of 'AnsibleUnsafeText' an…

### DIFF
--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -33,7 +33,7 @@ thread_cache_size       = {{ mysql_cache_size }}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
-{% if not '5.7' in mysql_ppa and not (ansible_distribution_major_version >= 16) %}
+{% if not '5.7' in mysql_ppa and not (ansible_distribution_major_version|int >= 16) %}
 # ** Not compatible with 5.7
 key_buffer              = {{ mysql_key_buffer }}
 myisam-recover          = {{ mysql_myisam_recover }}


### PR DESCRIPTION
…d 'int'