### PR TITLE
Fix mysql root password assignment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,4 @@ mysql_packages:
   - mysql-server
   - mysql-client
   - python-mysqldb
+  - libmysqlclient-dev

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -21,11 +21,10 @@
 
 - name: MySQL | Changing the root password (external hostname).
   mysql_user:
-    user: root
+    name: root
     host: "{{item}}"
     password: "{{mysql_root_password}}"
-    login_user: root
-    login_password: "{{mysql_default_root_password}}"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
     priv: "*.*:ALL,GRANT"
   with_items:
    - "{{ansible_hostname}}"
@@ -35,6 +34,8 @@
   when: "root_pw_already_set is failed and ansible_hostname != 'localhost'"
   tags:
     - change_root_password
+  become: yes
+  become_user: root
 
 - name: MySQL | Test whether the root password has already been changed (local hostname).
   mysql_user:
@@ -56,11 +57,10 @@
 
 - name: MySQL | Changing the root password (local hostname).
   mysql_user:
-    user: root
+    name: root
     host: "{{item}}"
     password: "{{mysql_root_password}}"
-    login_user: root
-    login_password: "{{mysql_default_root_password}}"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
     priv: "*.*:ALL,GRANT"
   with_items:
    - 127.0.0.1


### PR DESCRIPTION
- Use unix socket and root system user when setting mysql root user password

See ansible/ansible#44267 and ansible/ansible#27179